### PR TITLE
Replaying events

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Doing so will make the request faster, since it only has to check the log stream
 If you don't know the streams that need including, or you want to be sure you get all logs within that timestamp, it should be fine to continue without these, but be aware the request will take longer as a result.
 (If it's running for 10+ minutes for 150k log events across a period of a day, then something might be up.)
 
+Note that **you must be authenticated with AWS for this script to run**.
+
 The script writes its output to a file named `aws_logs.txt` in the current directory.
 
 ### filter-logs

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ There is no context in this repo to keep it as generic as possible.
 
 This script can be used to download logs from AWS CloudWatch.
 It assumes the logs in question are inside a log group called "matomo".
-Pass it two millisecond timestamps and it will download any errored requests from Nginx between those timestamps.
+Pass it two millisecond-timestamps and it will download any errored requests from Nginx between those timestamps.
 For example, to get logs from between 9:32 and 9:49 on 2019-01-01, pass in `1546507920000` and `1546508999999`:
 
 ```

--- a/README.md
+++ b/README.md
@@ -68,5 +68,6 @@ export MATOMO_PASSWORD=matomo_password
 ```
 
 Remember to move or copy your (ndjson) access log into the directory prior to building.
-(You can specify a different filename by changing the Dockerfile.)
+(You can specify a different filename by changing the bind mount `source` passed to the `docker run` command in
+`replay.sh`.)
 Best practice will also advise you not set the password variable through the command line.

--- a/README.md
+++ b/README.md
@@ -46,9 +46,13 @@ Note that if that output file already exists, the transformed output will be app
 
 ### replay-events
 
-This is essentially a Dockerfile used to define an environment with Python 2 to run the Matomo log analytics script.
-A fork is being used to handle `X-Forwarded-For` headers as given by AWS Application ELBs.
-The command itself has to be run manually once inside the docker image, as token authentication using Matomo hasn't worked in testing thus far, so authentication credentials need to be supplied directly.
+This contains a Dockerfile used to define an environment with Python 2 to run the Matomo log analytics script.
+An entrypoint script uses environment variables passed in from Docker to run the Matomo log analytics script to replay
+the events from a supplied JSON Nginx access log.
+A fork of the python is being used to handle `X-Forwarded-For` headers as given by AWS Application ELBs.
+Since token authentication using Matomo hasn't worked in testing thus far, authentication credentials need to be supplied to the script.
+This can be done by setting the `MATOMO_LOGIN` and `MATOMO_PASSWORD` environment variables appropriately.
+The `MATOMO_URL` environment variable should also be set to the Matomo base URL.
 
 There is a bash script suppied to simplify building and running the docker container.
 It tags the image `matomo-replay-events` by default.
@@ -57,20 +61,12 @@ An example workflow using this script might be something like this:
 ```
 mv download-logs/aws_logs.txt.ndjson replay-events/access.log
 cd replay-events
+export MATOMO_URL='https://my.matomo.url/'
+export MATOMO_LOGIN=matomo_username
+export MATOMO_PASSWORD=matomo_password
 ./replay.sh
-# inside docker container:
-python -u /log-analytics/import_logs.py \
-    --url=https://your.matomo.url/ \
-    --log-format-name=nginx_json \
-    --replay-tracking \
-    --enable-static \
-    --enable-bots \
-    --enable-reverse-dns \
-    --recorders=2 \
-    --login=matomo-username \
-    --password='matomo-password' \
-    /access.log
 ```
 
 Remember to move or copy your (ndjson) access log into the directory prior to building.
 (You can specify a different filename by changing the Dockerfile.)
+Best practice will also advise you not set the password variable through the command line.

--- a/README.md
+++ b/README.md
@@ -50,8 +50,13 @@ This contains a Dockerfile used to define an environment with Python 2 to run th
 An entrypoint script uses environment variables passed in from Docker to run the Matomo log analytics script to replay
 the events from a supplied JSON Nginx access log.
 A fork of the python is being used to handle `X-Forwarded-For` headers as given by AWS Application ELBs.
-Since token authentication using Matomo hasn't worked in testing thus far, authentication credentials need to be supplied to the script.
-This can be done by setting the `MATOMO_LOGIN` and `MATOMO_PASSWORD` environment variables appropriately.
+Since automatic token authentication using Matomo hasn't worked in testing thus far, a token needs to be manually
+supplied to the script.
+A token can be retrieved from the Matomo UI.
+In recent versions of Matomo: after logging in, go to the admin page (the cog) and go to the `Settings` page within
+the `Personal` group.
+An `API Authentication Token` is available towards the bottom of the page, and can be supplied to the script via the
+`MATOMO_TOKEN` environment variable.
 The `MATOMO_URL` environment variable should also be set to the Matomo base URL.
 
 There is a bash script suppied to simplify building and running the docker container.
@@ -62,12 +67,10 @@ An example workflow using this script might be something like this:
 mv download-logs/aws_logs.txt.ndjson replay-events/access.log
 cd replay-events
 export MATOMO_URL='https://my.matomo.url/'
-export MATOMO_LOGIN=matomo_username
-export MATOMO_PASSWORD=matomo_password
+export MATOMO_TOKEN=hex_string_here
 ./replay.sh
 ```
 
 Remember to move or copy your (ndjson) access log into the directory prior to building.
 (You can specify a different filename by changing the bind mount `source` passed to the `docker run` command in
 `replay.sh`.)
-Best practice will also advise you not set the password variable through the command line.

--- a/README.md
+++ b/README.md
@@ -49,13 +49,15 @@ Note that if that output file already exists, the transformed output will be app
 This is essentially a Dockerfile used to define an environment with Python 2 to run the Matomo log analytics script.
 A fork is being used to handle `X-Forwarded-For` headers as given by AWS Application ELBs.
 The command itself has to be run manually once inside the docker image, as token authentication using Matomo hasn't worked in testing thus far, so authentication credentials need to be supplied directly.
-An example workflow might be something like this:
+
+There is a bash script suppied to simplify building and running the docker container.
+It tags the image `matomo-replay-events` by default.
+An example workflow using this script might be something like this:
 
 ```
 mv download-logs/aws_logs.txt.ndjson replay-events/access.log
 cd replay-events
-docker build -t matomo-replay-events .
-docker run --rm -it matomo-replay-events
+./replay.sh
 # inside docker container:
 python -u /log-analytics/import_logs.py \
     --url=https://your.matomo.url/ \

--- a/README.md
+++ b/README.md
@@ -1,2 +1,72 @@
 # verify-matomo-utils
+
 Collection of tools used for interacting with Matomo (formerly called Piwik)
+
+## What is here?
+
+This is just a collection of helper scripts.
+The current intention is to make it easier to replay data into Matomo from Nginx logs in CloudWatch.
+More details about how to use them are included in other documentation.
+There is no context in this repo to keep it as generic as possible.
+(i.e. it shouldn't be exclusive to any individual Matomo setup.)
+
+### download-logs
+
+This script can be used to download logs from AWS CloudWatch.
+It assumes the logs in question are inside a log group called "matomo".
+Pass it two millisecond timestamps and it will download any errored requests from Nginx between those timestamps.
+For example, to get logs from between 9:32 and 9:49 on 2019-01-01, pass in `1546507920000` and `1546508999999`:
+
+```
+cd download-logs
+./download.sh 1546507920000 1546508999999
+```
+
+The script currently prompts you to continue, advising that you specify `--log-stream-name` arguments.
+Doing so will make the request faster, since it only has to check the log streams specified.
+If you don't know the streams that need including, or you want to be sure you get all logs within that timestamp, it should be fine to continue without these, but be aware the request will take longer as a result.
+(If it's running for 10+ minutes for 150k log events across a period of a day, then something might be up.)
+
+The script writes its output to a file named `aws_logs.txt` in the current directory.
+
+### filter-logs
+
+This script can be used to transform the output of `download-logs` back into an Nginx JSON format.
+It essentially strips the wrapper from the response to `download-logs` above, and then transforms the JSON array of events (where each element spans multiple lines) into a newline-delimited JSON (ndjson: each event is a separate JSON entity, on a single line) that the Matomo log analytics script can ingest.
+It is a Python 3 script, and expects to be passed as an argument a single file to transform, for example:
+
+```
+python3 filter-logs/filter-cloudwatch-logs.py download-logs/aws_logs.txt
+```
+
+By default, the above command would output a file `download-logs/aws_logs.txt.ndjson`.
+Note that if that output file already exists, the transformed output will be appended, rather than overwrite the existing data.
+
+### replay-events
+
+This is essentially a Dockerfile used to define an environment with Python 2 to run the Matomo log analytics script.
+A fork is being used to handle `X-Forwarded-For` headers as given by AWS Application ELBs.
+The command itself has to be run manually once inside the docker image, as token authentication using Matomo hasn't worked in testing thus far, so authentication credentials need to be supplied directly.
+An example workflow might be something like this:
+
+```
+mv download-logs/aws_logs.txt.ndjson replay-events/access.log
+cd replay-events
+docker build -t matomo-replay-events .
+docker run --rm -it matomo-replay-events
+# inside docker container:
+python -u /log-analytics/import_logs.py \
+    --url=https://your.matomo.url/ \
+    --log-format-name=nginx_json \
+    --replay-tracking \
+    --enable-static \
+    --enable-bots \
+    --enable-reverse-dns \
+    --recorders=2 \
+    --login=matomo-username \
+    --password='matomo-password' \
+    /access.log
+```
+
+Remember to move or copy your (ndjson) access log into the directory prior to building.
+(You can specify a different filename by changing the Dockerfile.)

--- a/download-logs/.gitignore
+++ b/download-logs/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!download.sh

--- a/download-logs/download.sh
+++ b/download-logs/download.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 numberregex='^[0-9]+$'
 if ! [[ $1 =~ ${numberregex} && $2 =~ ${numberregex} ]]; then
     echo "You must specify a start and end time in milliseconds."
@@ -17,6 +19,4 @@ read REPLY && if [[ $REPLY =~ ^[Yy]$ ]]; then
         --log-group-name "matomo" \
         --filter-pattern='{ $.status = 5* }' \
         > aws_logs.txt
-    exit $?
 fi
-exit 1

--- a/download-logs/download.sh
+++ b/download-logs/download.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+numberregex='^[0-9]+$'
+if ! [[ $1 =~ ${numberregex} && $2 =~ ${numberregex} ]]; then
+    echo "You must specify a start and end time in milliseconds."
+    exit 1
+fi
+
+echo "More specific results can be obtained by providing one or more '--log-stream-name' arguments."
+echo "Log stream names can be determined from CloudWatch in the console."
+echo "(You currently need to modify this script to add stream names.)"
+echo "Are you sure you wish to proceed? [yN]"
+read REPLY && if [[ $REPLY =~ ^[Yy]$ ]]; then
+    aws logs filter-log-events \
+        --start-time $1 \
+        --end-time $2 \
+        --log-group-name "matomo" \
+        --filter-pattern='{ $.status = 5* }' \
+        > aws_logs.txt
+    exit $?
+fi
+exit 1

--- a/filter-logs/.gitignore
+++ b/filter-logs/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!filter-cloudwatch-logs.py

--- a/filter-logs/filter-cloudwatch-logs.py
+++ b/filter-logs/filter-cloudwatch-logs.py
@@ -1,7 +1,47 @@
 #!/usr/bin/env python3
 
 import argparse
+import datetime
 import json
+
+
+class CloudwatchMatomoNginxLogStats:
+    def __init__(self):
+        self.total_count = 0
+        self.non_error_status_count = 0
+        self.smokey_count = 0
+        self.matomo_count = 0
+        self.piwik_count = 0
+        self.other_path_count = 0
+        self.other_paths = set()
+        self.hours = {}
+
+    def log_ingested_at(self, ingestion_time):
+        self.total_count += 1
+        # grouping by hour, requires conversion from milliseconds
+        parsed_timestamp = datetime.datetime.fromtimestamp(int(ingestion_time / 1000))
+        hour_representation = parsed_timestamp.strftime('%Y-%m-%d %H')
+        if hour_representation not in self.hours:
+            self.hours[hour_representation] = 1
+        else:
+            self.hours[hour_representation] += 1
+
+    def non_matomo_path(self, path):
+        self.other_path_count += 1
+        self.other_paths.add(path.split('?', 1)[0])
+
+    def report(self):
+        included = self.matomo_count + self.piwik_count
+        excluded = self.non_error_status_count + self.smokey_count + self.other_path_count
+        return (f'Encountered {self.total_count} messages, ({included} included, {excluded} excluded,) of which:'
+            + f'\n\tnon-error status (excluded): {self.non_error_status_count}'
+            + f'\n\tsmokey UA (excluded): {self.smokey_count}'
+            + f'\n\tnon-matomo paths (excluded): {self.other_path_count}'
+            + f'\n\tmatomo paths (included): {self.matomo_count}'
+            + f'\n\tpiwik paths (included): {self.piwik_count}'
+            + f'\nHours: {json.dumps(self.hours)}'
+            + f'\nNon-matomo paths encountered: {json.dumps(list(self.other_paths))}'
+        )
 
 
 def append_to_file(file, thing):
@@ -21,23 +61,37 @@ def file_to_json(path):
     return None
 
 
-def parse(aws_log_event):
+def parse(aws_log_event, stats):
+    stats.log_ingested_at(aws_log_event['ingestionTime'])
     # See https://github.com/matomo-org/matomo-log-analytics/blob/ec1f9c2f0dcaf680a27a0ef2676c0d1ab45e1ae2/import_logs.py#L159-L162
     #  for context as to why the replacement is done
-    return json.loads(aws_log_event['message'].replace('\\x', '\\u00'))
+    try:
+        return json.loads(aws_log_event['message'].replace('\\x', '\\u00'))
+    except json.decoder.JSONDecodeError as e:
+        print(f'Error encountered parsing log entry {aws_log_event["message"]}')
+        print(stats.report())
+        raise e
 
 
-def should_include(request_details):
+def should_include(request_details, stats):
     try:
         status = int(request_details['status'])
     except ValueError:
+        stats.non_error_status_count += 1
         return False
     if status < 500:
+        stats.non_error_status_count += 1
         return False
     if request_details['user_agent'] == 'Smokey Test':
+        stats.smokey_count += 1
         return False
     path = request_details['path']
-    if not (path[:11] == '/matomo.php' or path[:10] == '/piwik.php'):
+    if path[:11] == '/matomo.php':
+        stats.matomo_count += 1
+    elif path[:10] == '/piwik.php':
+        stats.piwik_count += 1
+    else:
+        stats.non_matomo_path(path)
         return False
     return True
 
@@ -54,11 +108,13 @@ def main():
         print('Failed to parse file.')
         return
     filtered_messages = []
+    stats = CloudwatchMatomoNginxLogStats()
     for event in aws_entries['events']:
-        request_details = parse(event)
-        if should_include(request_details):
+        request_details = parse(event, stats)
+        if should_include(request_details, stats):
             filtered_messages.append(request_details)
     append_many(output_path, filtered_messages)
+    print(stats.report())
 
 
 if __name__ == "__main__":

--- a/filter-logs/filter-cloudwatch-logs.py
+++ b/filter-logs/filter-cloudwatch-logs.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+
+
+def append_to_file(file, thing):
+    json.dump(thing, file)
+    file.write('\n')
+
+
+def append_many(path, iterable):
+    with open(path, 'a', encoding='utf8') as file:
+        for thing in iterable:
+            append_to_file(file, thing)
+
+
+def file_to_json(path):
+    with open(path, 'r') as file:
+        return json.load(file)
+    return None
+
+
+def parse(aws_log_event):
+    # See https://github.com/matomo-org/matomo-log-analytics/blob/ec1f9c2f0dcaf680a27a0ef2676c0d1ab45e1ae2/import_logs.py#L159-L162
+    #  for context as to why the replacement is done
+    return json.loads(aws_log_event['message'].replace('\\x', '\\u00'))
+
+
+def should_include(request_details):
+    try:
+        status = int(request_details['status'])
+    except ValueError:
+        return False
+    if status < 500:
+        return False
+    if request_details['user_agent'] == 'Smokey Test':
+        return False
+    path = request_details['path']
+    if not (path[:11] == '/matomo.php' or path[:10] == '/piwik.php'):
+        return False
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('input_path',
+            help='Path to the file downloaded from a call to `aws logs filter-log-events`')
+    args = parser.parse_args()
+    input_path = args.input_path
+    output_path = input_path + '.ndjson'
+    aws_entries = file_to_json(input_path)
+    if not aws_entries:
+        print('Failed to parse file.')
+        return
+    filtered_messages = []
+    for event in aws_entries['events']:
+        request_details = parse(event)
+        if should_include(request_details):
+            filtered_messages.append(request_details)
+    append_many(output_path, filtered_messages)
+
+
+if __name__ == "__main__":
+    main()

--- a/replay-events/.gitignore
+++ b/replay-events/.gitignore
@@ -1,4 +1,5 @@
 *
 !.gitignore
+!docker-entrypoint.sh
 !Dockerfile
 !replay.sh

--- a/replay-events/.gitignore
+++ b/replay-events/.gitignore
@@ -1,0 +1,4 @@
+*
+!.gitignore
+!Dockerfile
+!replay.sh

--- a/replay-events/Dockerfile
+++ b/replay-events/Dockerfile
@@ -1,11 +1,8 @@
-FROM alpine as analytics-fork
-
-RUN apk --update add --no-cache git
-RUN git clone --depth=1 https://github.com/adityapahuja/matomo-log-analytics.git
-
 FROM python:2-alpine
 
-COPY --from=analytics-fork /matomo-log-analytics /log-analytics
+RUN apk --update add --no-cache git
+RUN git clone --depth=1 https://github.com/adityapahuja/matomo-log-analytics.git log-analytics && \
+    rm -rf /log-analytics/.git
 COPY docker-entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/replay-events/Dockerfile
+++ b/replay-events/Dockerfile
@@ -6,6 +6,5 @@ RUN git clone --depth=1 https://github.com/adityapahuja/matomo-log-analytics.git
 FROM python:2-alpine
 
 COPY --from=analytics-fork /matomo-log-analytics /log-analytics
-COPY access.log /access.log
 
 ENTRYPOINT ["/bin/sh"]

--- a/replay-events/Dockerfile
+++ b/replay-events/Dockerfile
@@ -6,5 +6,6 @@ RUN git clone --depth=1 https://github.com/adityapahuja/matomo-log-analytics.git
 FROM python:2-alpine
 
 COPY --from=analytics-fork /matomo-log-analytics /log-analytics
+COPY docker-entrypoint.sh /entrypoint.sh
 
-ENTRYPOINT ["/bin/sh"]
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/replay-events/Dockerfile
+++ b/replay-events/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine as analytics-fork
+
+RUN apk --update add --no-cache git
+RUN git clone --depth=1 https://github.com/adityapahuja/matomo-log-analytics.git
+
+FROM python:2-alpine
+
+COPY --from=analytics-fork /matomo-log-analytics /log-analytics
+COPY access.log /access.log
+
+ENTRYPOINT ["/bin/sh"]

--- a/replay-events/docker-entrypoint.sh
+++ b/replay-events/docker-entrypoint.sh
@@ -4,19 +4,14 @@ if [ -z "${MATOMO_URL}" ]; then
     echo "No Matomo URL detected: aborting."
     exit 1
 fi
-if [ -z "${MATOMO_LOGIN}" ]; then
-    echo "No Matomo login detected: aborting."
-    exit 1
-fi
-if [ -z "${MATOMO_PASSWORD}" ]; then
-    echo "No Matomo password detected: aborting."
+if [ -z "${MATOMO_TOKEN}" ]; then
+    echo "No Matomo token detected: aborting."
     exit 1
 fi
 
 python -u /log-analytics/import_logs.py \
     --url="$MATOMO_URL" \
-    --login="$MATOMO_LOGIN" \
-    --password="$MATOMO_PASSWORD" \
+    --token-auth="$MATOMO_TOKEN" \
     --log-format-name=nginx_json \
     --replay-tracking \
     --enable-static \

--- a/replay-events/docker-entrypoint.sh
+++ b/replay-events/docker-entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+if [ -z "${MATOMO_URL}" ]; then
+    echo "No Matomo URL detected: aborting."
+    exit 1
+fi
+if [ -z "${MATOMO_LOGIN}" ]; then
+    echo "No Matomo login detected: aborting."
+    exit 1
+fi
+if [ -z "${MATOMO_PASSWORD}" ]; then
+    echo "No Matomo password detected: aborting."
+    exit 1
+fi
+
+python -u /log-analytics/import_logs.py \
+    --url="$MATOMO_URL" \
+    --login="$MATOMO_LOGIN" \
+    --password="$MATOMO_PASSWORD" \
+    --log-format-name=nginx_json \
+    --replay-tracking \
+    --enable-static \
+    --enable-bots \
+    --enable-reverse-dns \
+    --recorders=2 \
+    /access.log

--- a/replay-events/replay.sh
+++ b/replay-events/replay.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+if [ ! -f "access.log" ]; then
+    echo "Please copy the 'access.log' you wish to replay into this directory."
+    exit 1
+fi
+
+docker build -t matomo-import .
+
+cat << 'EOF'
+In the container, you will want to run a command like:
+python -u /log-analytics/import_logs.py \
+    --url=<matomo-url> \
+    --log-format-name=nginx_json \
+    --replay-tracking \
+    --enable-static \
+    --enable-bots \
+    --enable-reverse-dns \
+    --recorders=2 \
+    --login=<matomo-login> \
+    --password='<matomo-password>' \
+    /access.log
+Remember to substitute in your Matomo URL and login credentials.
+EOF
+
+docker run --rm -it matomo-import

--- a/replay-events/replay.sh
+++ b/replay-events/replay.sh
@@ -23,4 +23,6 @@ python -u /log-analytics/import_logs.py \
 Remember to substitute in your Matomo URL and login credentials.
 EOF
 
-docker run --rm -it matomo-import
+docker run --rm \
+    --mount type=bind,source="$(pwd)"/access.log,target=/access.log \
+    -it matomo-import

--- a/replay-events/replay.sh
+++ b/replay-events/replay.sh
@@ -7,9 +7,9 @@ if [ -z "${MATOMO_URL}" ]; then
     echo "This is done by setting the \"MATOMO_URL\" variable."
     exit 1
 fi
-if [ -z "${MATOMO_LOGIN}" ] || [ -z "${MATOMO_PASSWORD}" ]; then
-    echo "Please ensure you specify credentials for Matomo."
-    echo "This is done by setting the \"MATOMO_LOGIN\" and \"MATOMO_PASSWORD\" variables."
+if [ -z "${MATOMO_TOKEN}" ]; then
+    echo "Please ensure you specify an access token for Matomo."
+    echo "This can be provided through the \"MATOMO_TOKEN\" variable."
     exit 1
 fi
 
@@ -23,6 +23,5 @@ docker build -t matomo-replay-events .
 docker run --rm \
     --mount type=bind,source="$(pwd)"/access.log,target=/access.log \
     -e MATOMO_URL \
-    -e MATOMO_LOGIN \
-    -e MATOMO_PASSWORD \
+    -e MATOMO_TOKEN \
     -it matomo-replay-events

--- a/replay-events/replay.sh
+++ b/replay-events/replay.sh
@@ -5,7 +5,7 @@ if [ ! -f "access.log" ]; then
     exit 1
 fi
 
-docker build -t matomo-import .
+docker build -t matomo-replay-events .
 
 cat << 'EOF'
 In the container, you will want to run a command like:
@@ -25,4 +25,4 @@ EOF
 
 docker run --rm \
     --mount type=bind,source="$(pwd)"/access.log,target=/access.log \
-    -it matomo-import
+    -it matomo-replay-events

--- a/replay-events/replay.sh
+++ b/replay-events/replay.sh
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
 
+set -e
+
+if [ -z "${MATOMO_URL}" ]; then
+    echo "Please ensure you specify a valid URL for Matomo."
+    echo "This is done by setting the \"MATOMO_URL\" variable."
+    exit 1
+fi
+if [ -z "${MATOMO_LOGIN}" ] || [ -z "${MATOMO_PASSWORD}" ]; then
+    echo "Please ensure you specify credentials for Matomo."
+    echo "This is done by setting the \"MATOMO_LOGIN\" and \"MATOMO_PASSWORD\" variables."
+    exit 1
+fi
+
 if [ ! -f "access.log" ]; then
     echo "Please copy the 'access.log' you wish to replay into this directory."
     exit 1
@@ -7,22 +20,9 @@ fi
 
 docker build -t matomo-replay-events .
 
-cat << 'EOF'
-In the container, you will want to run a command like:
-python -u /log-analytics/import_logs.py \
-    --url=<matomo-url> \
-    --log-format-name=nginx_json \
-    --replay-tracking \
-    --enable-static \
-    --enable-bots \
-    --enable-reverse-dns \
-    --recorders=2 \
-    --login=<matomo-login> \
-    --password='<matomo-password>' \
-    /access.log
-Remember to substitute in your Matomo URL and login credentials.
-EOF
-
 docker run --rm \
     --mount type=bind,source="$(pwd)"/access.log,target=/access.log \
+    -e MATOMO_URL \
+    -e MATOMO_LOGIN \
+    -e MATOMO_PASSWORD \
     -it matomo-replay-events


### PR DESCRIPTION
Adds scripts to:

- download logs from CloudWatch
    - you have to authenticate with AWS first
- clean, filter and sort the download, ready for replaying
- prepare a Docker container ready to replay the data into Matomo
    - the script builds a Docker image, runs a container, and opens the command line; the command that needs to be run requires Matomo credentials, so is not currently automated.

There aren't any tests for anything, but I'm also not entirely sure what we can test. Maybe that the input and output formats of the filter script are what we expect, but is that worthwhile adding? Anything else?